### PR TITLE
Use rodne_cislo for auth and add CORS env config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,4 +4,16 @@ DB_PASSWORD=npg_WBIT0wEuGn6D
 DB_HOST=ep-hidden-pine-abwglofu-pooler.eu-west-2.aws.neon.tech
 DB_NAME=neondb
 DB_PORT=5432
+<<<<<<< Updated upstream
 SECRET_KEY=manu
+=======
+
+# --- AUTH ---
+SECRET_KEY=your_secret_key_here
+
+# --- CORS ---
+# Con Caddy como reverse proxy, frontend y API comparten origen (CORS no aplica).
+# Estos orígenes cubren acceso directo al backend sin Caddy.
+# Prod: CORS_ORIGINS=https://tudominio.com,https://www.tudominio.com
+CORS_ORIGINS=https://localhost,https://localhost:3000,http://localhost:3000
+>>>>>>> Stashed changes

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,44 @@
+# ============================================================
+# ErasmusHub — Reverse Proxy con HTTPS (Caddy)
+# ============================================================
+#
+# Caddy sirve AMBOS servicios (frontend + API) bajo un SOLO
+# origen HTTPS, lo que:
+#   1. Habilita PWA/Service Workers en todos los navegadores y móviles
+#   2. Elimina problemas de CORS (mismo origen)
+#   3. Simplifica la configuración
+#
+# DESARROLLO (actual):
+#   - Accede a https://localhost → frontend Next.js
+#   - Las peticiones a https://localhost/api/* → backend FastAPI
+#   - "tls internal" genera certificados autofirmados automáticamente
+#
+# ACCESO DESDE MÓVILES (misma red WiFi):
+#   Añade la IP de tu equipo al bloque de sitios:
+#     localhost, 192.168.x.x { ... }
+#   Luego en el móvil abre https://192.168.x.x y acepta el
+#   certificado, o instala la CA de Caddy:
+#     docker cp erasmushub_caddy:/data/caddy/pki/authorities/local/root.crt .
+#
+# PRODUCCIÓN:
+#   Cambia "localhost" por tu dominio real y elimina "tls internal".
+#   Caddy obtendrá certificados Let's Encrypt automáticamente.
+#     erasmushub.com {
+#         handle_path /api/* { reverse_proxy backend:8000 }
+#         handle { reverse_proxy frontend:3000 }
+#     }
+# ============================================================
+
+localhost {
+    tls internal
+
+    # Peticiones a /api/* → FastAPI (se elimina el prefijo /api)
+    handle_path /api/* {
+        reverse_proxy host.docker.internal:8000
+    }
+
+    # Todo lo demás → Next.js frontend
+    handle {
+        reverse_proxy host.docker.internal:3000
+    }
+}

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -13,11 +13,15 @@ router = APIRouter(prefix="/auth", tags=["Auth"])
 
 @router.post("/login", response_model=Token)
 def login(credentials: LoginRequest, db: Session = Depends(get_session)):
-    user = authenticate_user(db, credentials.email, credentials.password)
+    user = authenticate_user(db, credentials.rodne_cislo, credentials.password)
     if not user:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
+<<<<<<< Updated upstream
             detail="Incorrect email or password",
+=======
+            detail="DNI o contraseña incorrectos",
+>>>>>>> Stashed changes
             headers={"WWW-Authenticate": "Bearer"},
         )
     token = create_access_token(subject=user.id)

--- a/api/routes/users.py
+++ b/api/routes/users.py
@@ -12,6 +12,7 @@ router = APIRouter(tags=["Users"])
 
 @router.post("/users/", response_model=UserPublic, status_code=status.HTTP_201_CREATED)
 def create_user(user_in: UserCreate, db: Session = Depends(get_session)):
+<<<<<<< Updated upstream
     existing_user = db.exec(select(User).where(User.email == user_in.email)).first()
     if existing_user:
         raise HTTPException(status_code=400, detail="Email already registered")
@@ -26,6 +27,24 @@ def create_user(user_in: UserCreate, db: Session = Depends(get_session)):
         address=user_in.address,
         phone=user_in.phone,
         is_minor=user_in.is_minor,
+=======
+    # 1. Verificar si ya existe el email o rodne_cislo
+    existing_email = db.exec(select(Usuario).where(Usuario.email == user_in.email)).first()
+    if existing_email:
+        raise HTTPException(status_code=400, detail="El email ya está registrado")
+
+    existing_dni = db.exec(select(Usuario).where(Usuario.rodne_cislo == user_in.rodne_cislo)).first()
+    if existing_dni:
+        raise HTTPException(status_code=400, detail="El DNI ya está registrado")
+
+    # 2. Convertir Schema -> Model (y hashear password)
+    db_user = Usuario(
+        rodne_cislo=user_in.rodne_cislo,
+        email=user_in.email,
+        nombre=user_in.nombre,
+        apellidos=user_in.apellidos,
+        password_hash=get_password_hash(user_in.password)
+>>>>>>> Stashed changes
     )
 
     db.add(db_user)

--- a/app/main.py
+++ b/app/main.py
@@ -35,7 +35,18 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 
+<<<<<<< Updated upstream
 cors_origins = os.getenv("CORS_ORIGINS", "http://localhost:3000").split(",")
+=======
+# CORS — Con Caddy como reverse proxy, frontend y API comparten origen
+# (mismo dominio/puerto), así que CORS no se activa para peticiones normales.
+# Estos orígenes cubren acceso directo al backend sin Caddy (ej: desarrollo).
+_origins = os.getenv(
+    "CORS_ORIGINS",
+    "http://localhost:3000,http://127.0.0.1:3000,https://localhost:3000,https://localhost,http://localhost"
+)
+origins = [o.strip() for o in _origins.split(",")]
+>>>>>>> Stashed changes
 
 app.add_middleware(
     CORSMiddleware,

--- a/models/user.py
+++ b/models/user.py
@@ -20,7 +20,11 @@ class User(SQLModel, table=True):
 
     # Fields matching your SQL schema
     id: Optional[int] = Field(default=None, primary_key=True, index=True)
+<<<<<<< Updated upstream
     rodne_cislo: Optional[str] = Field(default=None, unique=True, index=True)
+=======
+    rodne_cislo: str = Field(unique=True, index=True)
+>>>>>>> Stashed changes
     email: str = Field(unique=True, index=True)
     password_hash: str
     first_name: str

--- a/schemas/auth_schema.py
+++ b/schemas/auth_schema.py
@@ -1,8 +1,8 @@
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel
 
 
 class LoginRequest(BaseModel):
-    email: EmailStr
+    rodne_cislo: str
     password: str
 
 

--- a/schemas/user_schema.py
+++ b/schemas/user_schema.py
@@ -4,6 +4,7 @@ from typing import Optional, List
 
 
 class UserBase(BaseModel):
+    rodne_cislo: str
     email: EmailStr
     first_name: str
     last_name: str
@@ -19,6 +20,7 @@ class UserCreate(UserBase):
 
 
 class UserUpdate(BaseModel):
+    rodne_cislo: Optional[str] = None
     email: Optional[EmailStr] = None
     first_name: Optional[str] = None
     last_name: Optional[str] = None

--- a/services/auth_service.py
+++ b/services/auth_service.py
@@ -3,8 +3,13 @@ from models.user import User
 from core.security import verify_password
 
 
+<<<<<<< Updated upstream
 def authenticate_user(db: Session, email: str, password: str) -> User | None:
     user = db.exec(select(User).where(User.email == email)).first()
+=======
+def authenticate_user(db: Session, rodne_cislo: str, password: str) -> Usuario | None:
+    user = db.exec(select(Usuario).where(Usuario.rodne_cislo == rodne_cislo)).first()
+>>>>>>> Stashed changes
     if not user or not verify_password(password, user.password_hash):
         return None
     return user


### PR DESCRIPTION
Migrate authentication from email to rodne_cislo (DNI) across the codebase: update LoginRequest schema, user schemas, User model (rodne_cislo field), auth_service authenticate_user signature, and auth route to use rodne_cislo and adjusted error text. Enhance user creation to validate both email and rodne_cislo uniqueness and construct the user model with a hashed password. Add parsing of CORS origins in app/main and expand .env.example with SECRET_KEY and CORS_ORIGINS examples for local/dev usage. Note: several files contain unresolved merge conflict markers (<<<<<<< / ======= / >>>>>>>) that must be manually resolved before finalizing.

## ✨ Descripción
(Describe brevemente qué añade o corrige este Pull Request.)

## 🔗 Issue relacionado
Fixes #9 
<!-- Ejemplo: Fixes #21 -->

---