### PR TITLE
Use DNI for auth; add DNI uniqueness check

### DIFF
--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -17,11 +17,7 @@ def login(credentials: LoginRequest, db: Session = Depends(get_session)):
     if not user:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-<<<<<<< Updated upstream
-            detail="Incorrect email or password",
-=======
             detail="DNI o contraseña incorrectos",
->>>>>>> Stashed changes
             headers={"WWW-Authenticate": "Bearer"},
         )
     token = create_access_token(subject=user.id)

--- a/api/routes/users.py
+++ b/api/routes/users.py
@@ -12,10 +12,14 @@ router = APIRouter(tags=["Users"])
 
 @router.post("/users/", response_model=UserPublic, status_code=status.HTTP_201_CREATED)
 def create_user(user_in: UserCreate, db: Session = Depends(get_session)):
-<<<<<<< Updated upstream
     existing_user = db.exec(select(User).where(User.email == user_in.email)).first()
     if existing_user:
         raise HTTPException(status_code=400, detail="Email already registered")
+
+    if user_in.rodne_cislo:
+        existing_dni = db.exec(select(User).where(User.rodne_cislo == user_in.rodne_cislo)).first()
+        if existing_dni:
+            raise HTTPException(status_code=400, detail="DNI already registered")
 
     db_user = User(
         email=user_in.email,
@@ -27,24 +31,6 @@ def create_user(user_in: UserCreate, db: Session = Depends(get_session)):
         address=user_in.address,
         phone=user_in.phone,
         is_minor=user_in.is_minor,
-=======
-    # 1. Verificar si ya existe el email o rodne_cislo
-    existing_email = db.exec(select(Usuario).where(Usuario.email == user_in.email)).first()
-    if existing_email:
-        raise HTTPException(status_code=400, detail="El email ya está registrado")
-
-    existing_dni = db.exec(select(Usuario).where(Usuario.rodne_cislo == user_in.rodne_cislo)).first()
-    if existing_dni:
-        raise HTTPException(status_code=400, detail="El DNI ya está registrado")
-
-    # 2. Convertir Schema -> Model (y hashear password)
-    db_user = Usuario(
-        rodne_cislo=user_in.rodne_cislo,
-        email=user_in.email,
-        nombre=user_in.nombre,
-        apellidos=user_in.apellidos,
-        password_hash=get_password_hash(user_in.password)
->>>>>>> Stashed changes
     )
 
     db.add(db_user)

--- a/app/main.py
+++ b/app/main.py
@@ -35,18 +35,11 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 
-<<<<<<< Updated upstream
-cors_origins = os.getenv("CORS_ORIGINS", "http://localhost:3000").split(",")
-=======
-# CORS — Con Caddy como reverse proxy, frontend y API comparten origen
-# (mismo dominio/puerto), así que CORS no se activa para peticiones normales.
-# Estos orígenes cubren acceso directo al backend sin Caddy (ej: desarrollo).
-_origins = os.getenv(
+cors_origins = os.getenv(
     "CORS_ORIGINS",
     "http://localhost:3000,http://127.0.0.1:3000,https://localhost:3000,https://localhost,http://localhost"
-)
-origins = [o.strip() for o in _origins.split(",")]
->>>>>>> Stashed changes
+).split(",")
+cors_origins = [o.strip() for o in cors_origins]
 
 app.add_middleware(
     CORSMiddleware,

--- a/schemas/user_schema.py
+++ b/schemas/user_schema.py
@@ -4,7 +4,6 @@ from typing import Optional, List
 
 
 class UserBase(BaseModel):
-    rodne_cislo: str
     email: EmailStr
     first_name: str
     last_name: str
@@ -20,7 +19,6 @@ class UserCreate(UserBase):
 
 
 class UserUpdate(BaseModel):
-    rodne_cislo: Optional[str] = None
     email: Optional[EmailStr] = None
     first_name: Optional[str] = None
     last_name: Optional[str] = None

--- a/services/auth_service.py
+++ b/services/auth_service.py
@@ -3,13 +3,8 @@ from models.user import User
 from core.security import verify_password
 
 
-<<<<<<< Updated upstream
-def authenticate_user(db: Session, email: str, password: str) -> User | None:
-    user = db.exec(select(User).where(User.email == email)).first()
-=======
-def authenticate_user(db: Session, rodne_cislo: str, password: str) -> Usuario | None:
-    user = db.exec(select(Usuario).where(Usuario.rodne_cislo == rodne_cislo)).first()
->>>>>>> Stashed changes
+def authenticate_user(db: Session, rodne_cislo: str, password: str) -> User | None:
+    user = db.exec(select(User).where(User.rodne_cislo == rodne_cislo)).first()
     if not user or not verify_password(password, user.password_hash):
         return None
     return user


### PR DESCRIPTION
Switch authentication to use rodne_cislo (DNI) instead of email: updated authenticate_user and login flow to query by rodne_cislo and return localized error message. Add a DNI uniqueness check when creating users to prevent duplicate rodne_cislo entries. Remove rodne_cislo from UserBase and UserUpdate schemas (no longer required in base/update models). Clean up CORS origin parsing to split and strip environment variable entries. Also resolves merge/conflict artifacts and standardizes usage of the User model and rodne_cislo across services and routes.

## ✨ Descripción
(Describe brevemente qué añade o corrige este Pull Request.)

## 🔗 Issue relacionado
Fixes #9 
<!-- Ejemplo: Fixes #21 -->

---